### PR TITLE
0.50.2: update current_release

### DIFF
--- a/Formula/hab.rb
+++ b/Formula/hab.rb
@@ -1,7 +1,7 @@
 class Hab < Formula
   # Update these values as needed as new versions are released
   current_version="0.50.2"
-  current_release="20171128173702"
+  current_release="20171201033503"
   current_sha256="ab5609d3c6a78457ae52911d4ba32c75c7cd96d0cb16f71f0d129c3356504485"
 
   desc "The Habitat command line application"


### PR DESCRIPTION
I've pushed this to my fork's `master`, so it can be tested using

    brew tap srenatus/homebrew-habitat
    brew upgrade srenatus/habitat/hab