### PR TITLE
Add openssl as a recommended dependency

### DIFF
--- a/Formula/hab.rb
+++ b/Formula/hab.rb
@@ -4,6 +4,15 @@ class Hab < Formula
   current_release="20180321215236"
   current_sha256="fdc87f2e82b8ef0b82f5b9fb56b56b24a45277e92f48e0ef58fdd6270513c53a"
 
+  # Installing "openssl" ensures there's a certificate chain at
+  # `/usr/local/etc/openssl/cert.pem`, which our OpenSSL library needs
+  # in order to work.
+  #
+  # Users can install using `--without-openssl` if they don't want
+  # this, in which case, they'll need to set `SSL_CERT_FILE` and / or
+  # `SSL_CERT_DIR` to appropriate values.
+  depends_on "openssl" => :recommended
+
   desc "The Habitat command line application"
   homepage "https://habitat.sh"
   url "https://bintray.com/habitat/stable/download_file?file_path=darwin%2Fx86_64%2Fhab-#{current_version}-#{current_release}-x86_64-darwin.zip"


### PR DESCRIPTION
`hab` uses the OpenSSL library in order to make secure HTTPS
connections to the Builder service. In order to do this, it must have
access to the necessary certificates in order to establish trust. The
easiest way to do this on MacOS is to use Homebrew to also install
`openssl`, which generates a `/usr/local/etc/openssl/cert.pem` file
based on the contents of the SystemRoots keychain.

If this file is not present, users will see the following error
message (wrapped for presentation purposes):

```
the handshake failed: The OpenSSL library reported an error:
error:14090086:SSL routines:ssl3_get_server_certificate:certificate
verify failed:s3_clnt.c:1264:: unable to get local issuer certificate
```

In this commit, `openssl` is added as a "recommended" Homebrew
dependency. This means that it will be installed by default when a
user runs `brew install hab`. Should the user not want to install
`openssl` from Homebrew, they can install `hab` like this:

```sh
brew install hab --without-openssl
```

They will then be responsible for telling `hab` where it can find
certificates, using the OpenSSL standard environment variables
`SSL_CERT_FILE` and/or `SSL_CERT_DIR`.

Signed-off-by: Christopher Maier <cmaier@chef.io>