### PR TITLE
Remove openssl dependency

### DIFF
--- a/.expeditor/scripts/verify/install_from_tap.sh
+++ b/.expeditor/scripts/verify/install_from_tap.sh
@@ -34,7 +34,10 @@ git checkout "${BUILDKITE_BRANCH}"
 
 echo "--- Installing hab from ${BUILDKITE_BRANCH}"
 # Without setting HOMEBREW_DEVELOPER, `brew install` will
-#automatically re-check-out the master branch of the tap!
+# automatically re-check-out the master branch of the tap!
+#
+# (Also, for future reference, you have to be on a branch, not a
+# detached HEAD, in order for this to work.)
 export HOMEBREW_DEVELOPER=1
 brew install hab
 

--- a/Formula/hab.rb
+++ b/Formula/hab.rb
@@ -8,15 +8,6 @@ class Hab < Formula
     "https://packages.chef.io/files/habitat/#{current_version}/hab-x86_64-darwin.zip"
   end
 
-  # Installing "openssl" ensures there's a certificate chain at
-  # `/usr/local/etc/openssl/cert.pem`, which our OpenSSL library needs
-  # in order to work.
-  #
-  # Users can install using `--without-openssl` if they don't want
-  # this, in which case, they'll need to set `SSL_CERT_FILE` and / or
-  # `SSL_CERT_DIR` to appropriate values.
-  depends_on "openssl" => :recommended
-
   desc "The Habitat command line application"
   homepage "https://habitat.sh"
   url source_url


### PR DESCRIPTION
The `openssl` formula has been removed from Homebrew.

Signed-off-by: Christopher Maier <cmaier@chef.io>