### PR TITLE
Support arm m1 macs

### DIFF
--- a/.expeditor/scripts/bump_version.sh
+++ b/.expeditor/scripts/bump_version.sh
@@ -26,7 +26,8 @@ get_manifest() {
 }
 
 version="$(get_manifest | jq -r '.version')"
-sha256="$(curl "${url_prefix}/hab-x86_64-darwin.zip.sha256sum" | cut -d' ' -f1)"
+darwin_intel_sha256="$(curl "${url_prefix}/hab-x86_64-darwin.zip.sha256sum" | cut -d' ' -f1)"
+darwin_arm_sha256="$(curl "${url_prefix}/hab-aarch64-darwin.zip.sha256sum" | cut -d' ' -f1)"
 
 branch="ci/brew-update-$version-$(date +"%Y%m%d%H%M%S")"
 git checkout -b "$branch"
@@ -41,7 +42,11 @@ git add Formula/hab.rb
 
 sed --in-place \
     --regexp-extended \
-    's/current_sha256="(.*)"/current_sha256="'"${sha256}"'"/g' \
+    's/current_darwin_intel_sha256="(.*)"/current_darwin_intel_sha256="'"${darwin_intel_sha256}"'"/g' \
+    Formula/hab.rb
+sed --in-place \
+    --regexp-extended \
+    's/current_darwin_arm_sha256="(.*)"/current_darwin_arm_sha256="'"${darwin_arm_sha256}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb

--- a/.expeditor/scripts/bump_version.sh
+++ b/.expeditor/scripts/bump_version.sh
@@ -41,18 +41,18 @@ git checkout -b "$branch"
 echo "--- Modifying hab Homebrew Formula"
 sed --in-place \
     --regexp-extended \
-    's/current_version(\s*=\s*)".*"/current_version\1"'"${version}"'"/g' \
+    's/(current_version\s*=\s*)".*"/\1"'"${version}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb
 
 sed --in-place \
     --regexp-extended \
-    's/current_darwin_intel_sha256(\s*=\s*)".*"/current_darwin_intel_sha256\1"'"${darwin_intel_sha256}"'"/g' \
+    's/(current_darwin_intel_sha256\s*=\s*)".*"/\1"'"${darwin_intel_sha256}"'"/g' \
     Formula/hab.rb
 sed --in-place \
     --regexp-extended \
-    's/current_darwin_arm_sha256(\s*=\s*)".*"/current_darwin_arm_sha256\1"'"${darwin_arm_sha256}"'"/g' \
+    's/(current_darwin_arm_sha256\s*=\s*)".*"/\1"'"${darwin_arm_sha256}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb

--- a/.expeditor/scripts/bump_version.sh
+++ b/.expeditor/scripts/bump_version.sh
@@ -41,7 +41,7 @@ git checkout -b "$branch"
 echo "--- Modifying hab Homebrew Formula"
 sed --in-place \
     --regexp-extended \
-    's/current_version(\s+=\s+)".*"/current_version\1"'"${version}"'"/g' \
+    's/current_version(\s*=\s*)".*"/current_version\1"'"${version}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb

--- a/.expeditor/scripts/bump_version.sh
+++ b/.expeditor/scripts/bump_version.sh
@@ -26,8 +26,7 @@ get_manifest() {
 }
 
 version="$(get_manifest | jq -r '.version')"
-darwin_intel_sha256="$(curl "${url_prefix}/hab-x86_64-darwin.zip.sha256sum" | cut -d' ' -f1)"
-darwin_arm_sha256="$(curl "${url_prefix}/hab-aarch64-darwin.zip.sha256sum" | cut -d' ' -f1)"
+sha256="$(curl "${url_prefix}/hab-x86_64-darwin.zip.sha256sum" | cut -d' ' -f1)"
 
 branch="ci/brew-update-$version-$(date +"%Y%m%d%H%M%S")"
 git checkout -b "$branch"
@@ -42,11 +41,7 @@ git add Formula/hab.rb
 
 sed --in-place \
     --regexp-extended \
-    's/current_darwin_intel_sha256="(.*)"/current_darwin_intel_sha256="'"${darwin_intel_sha256}"'"/g' \
-    Formula/hab.rb
-sed --in-place \
-    --regexp-extended \
-    's/current_darwin_arm_sha256="(.*)"/current_darwin_arm_sha256="'"${darwin_arm_sha256}"'"/g' \
+    's/current_sha256="(.*)"/current_sha256="'"${sha256}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb

--- a/.expeditor/scripts/bump_version.sh
+++ b/.expeditor/scripts/bump_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script automates the modification of our Homebrew tap for the
 # `hab` binary.
@@ -48,11 +48,11 @@ git add Formula/hab.rb
 
 sed --in-place \
     --regexp-extended \
-    's/current_darwin_intel_sha256="(.*)"/current_darwin_intel_sha256="'"${darwin_intel_sha256}"'"/g' \
+    's/current_darwin_intel_sha256(\s*=\s*)".*"/current_darwin_intel_sha256\1"'"${darwin_intel_sha256}"'"/g' \
     Formula/hab.rb
 sed --in-place \
     --regexp-extended \
-    's/current_darwin_arm_sha256="(.*)"/current_darwin_arm_sha256="'"${darwin_arm_sha256}"'"/g' \
+    's/current_darwin_arm_sha256(\s*=\s*)".*"/current_darwin_arm_sha256\1"'"${darwin_arm_sha256}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb

--- a/.expeditor/scripts/bump_version.sh
+++ b/.expeditor/scripts/bump_version.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-
+#
 # This script automates the modification of our Homebrew tap for the
 # `hab` binary.
 
 set -euo pipefail
+
+if [[ $(uname -s) == Darwin ]]; then
+  function sed() {
+      command gsed "$@"
+  }
+fi
 
 url_prefix="https://packages.chef.io/files/stable/habitat/latest/"
 
@@ -26,7 +32,8 @@ get_manifest() {
 }
 
 version="$(get_manifest | jq -r '.version')"
-sha256="$(curl "${url_prefix}/hab-x86_64-darwin.zip.sha256sum" | cut -d' ' -f1)"
+darwin_intel_sha256="$(curl "${url_prefix}/hab-x86_64-darwin.zip.sha256sum" | cut -d' ' -f1)"
+darwin_arm_sha256="$(curl "${url_prefix}/hab-aarch64-darwin.zip.sha256sum" | cut -d' ' -f1)"
 
 branch="ci/brew-update-$version-$(date +"%Y%m%d%H%M%S")"
 git checkout -b "$branch"
@@ -41,7 +48,11 @@ git add Formula/hab.rb
 
 sed --in-place \
     --regexp-extended \
-    's/current_sha256="(.*)"/current_sha256="'"${sha256}"'"/g' \
+    's/current_darwin_intel_sha256="(.*)"/current_darwin_intel_sha256="'"${darwin_intel_sha256}"'"/g' \
+    Formula/hab.rb
+sed --in-place \
+    --regexp-extended \
+    's/current_darwin_arm_sha256="(.*)"/current_darwin_arm_sha256="'"${darwin_arm_sha256}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb

--- a/.expeditor/scripts/bump_version.sh
+++ b/.expeditor/scripts/bump_version.sh
@@ -41,7 +41,7 @@ git checkout -b "$branch"
 echo "--- Modifying hab Homebrew Formula"
 sed --in-place \
     --regexp-extended \
-    's/current_version="(.*)"/current_version="'"${version}"'"/g' \
+    's/current_version(\s+=\s+)".*"/current_version\1"'"${version}"'"/g' \
     Formula/hab.rb
 ensure_files_changed
 git add Formula/hab.rb

--- a/Formula/hab.rb
+++ b/Formula/hab.rb
@@ -2,7 +2,7 @@ class Hab < Formula
   # Update these values as needed as new versions are released
   current_version = "1.6.521"
   current_darwin_intel_sha256 = "7d83af8e267bed3865be3be102a21040fa03555dcf76f9d6f220dd66e614aa8c"
-  current_darwin_arm_sha256 = "7d83af8e267bed3865be3be102a21040fa03555dcf76f9d6f220dd66e614aa8c"
+  current_darwin_arm_sha256 = "1fac2a9560c2da917d46bb81a3ae6debb8911d6f41dda1b12579de5e1e8150b1"
 
   on_macos do
     @source_os = "darwin"

--- a/Formula/hab.rb
+++ b/Formula/hab.rb
@@ -1,18 +1,33 @@
 class Hab < Formula
   # Update these values as needed as new versions are released
-  current_version="1.6.521"
-  current_sha256="7d83af8e267bed3865be3be102a21040fa03555dcf76f9d6f220dd66e614aa8c"
-  source_url = if current_version == "0.88.0"
-    "https://bintray.com/habitat/stable/download_file?file_path=darwin%2Fx86_64%2Fhab-0.88.0-20191009205151-x86_64-darwin.zip"
-  else
-    "https://packages.chef.io/files/habitat/#{current_version}/hab-x86_64-darwin.zip"
+  current_version = "1.6.521"
+  current_darwin_intel_sha256 = "7d83af8e267bed3865be3be102a21040fa03555dcf76f9d6f220dd66e614aa8c"
+  current_darwin_arm_sha256 = "7d83af8e267bed3865be3be102a21040fa03555dcf76f9d6f220dd66e614aa8c"
+
+  on_macos do
+    @source_os = "darwin"
+    if Hardware::CPU.arm?
+      @source_sha256 = current_darwin_arm_sha256
+      @source_arch = "aarch64"
+    elsif Hardware::CPU.intel?
+      @source_sha256 = current_darwin_intel_sha256
+      @source_arch = "x86_64"
+    end
   end
+  on_linux do
+    raise "linux not supported"
+  end
+  source_url = if current_version == "0.88.0"
+                 "https://bintray.com/habitat/stable/download_file?file_path=darwin%2Fx86_64%2Fhab-0.88.0-20191009205151-x86_64-darwin.zip"
+               else
+                 "https://packages.chef.io/files/habitat/#{current_version}/hab-#{@source_arch}-#{@source_os}.zip"
+               end
 
   desc "The Habitat command line application"
   homepage "https://habitat.sh"
   url source_url
   version current_version
-  sha256 current_sha256.downcase
+  sha256 @source_sha256
 
   def install
     bin.install "hab"


### PR DESCRIPTION
Support M1 (arm64) macs:

- Allow running the bump script locally (by running gsed for sed options not on mac)
- Figure out the source (destination?) os and arch
- Make the bump script resilient to Ruby formatting (spaces around `=`)
- Make bump script bump both shas

/cc @mwrock 